### PR TITLE
added caching, fixed the description, and tweaked a few things

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,12 @@ const CONFIG_SCHEMA = {
           title: 'API Key (optional)',
           default: '',
           description: 'Leave blank for free personal use. Go to https://open-meteo.com for a paid API.'
+        },
+        cacheTTL: {
+          type: 'number',
+          title: 'Cache TTL (minutes)',
+          default: 10,
+          description: 'How long to cache weather data before fetching fresh data.'
         }
       }
     }
@@ -47,7 +53,8 @@ module.exports = (server: OpenMeteoProviderApp): Plugin => {
   // ** default configuration settings
   let settings: SETTINGS = {
     weather: {
-      apiKey: ''
+      apiKey: '',
+      cacheTTL: 10
     }
   }
 
@@ -82,9 +89,11 @@ module.exports = (server: OpenMeteoProviderApp): Plugin => {
       }
 
       settings.weather = options.weather ?? {
-        apiKey: ''
+        apiKey: '',
+        cacheTTL: 10
       }
       settings.weather.apiKey = options.weather.apiKey ?? ''
+      settings.weather.cacheTTL = options.weather.cacheTTL ?? 10
 
       server.debug(`Applied config: ${JSON.stringify(settings)}`)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ const CONFIG_SCHEMA = {
           type: 'string',
           title: 'API Key (optional)',
           default: '',
-          description: 'Get your API key at https://open-meteo.org'
+          description: 'Leave blank for free personal use. Get an API key at https://open-meteo.com for commercial use or higher rate limits.'
         }
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ const CONFIG_SCHEMA = {
           type: 'string',
           title: 'API Key (optional)',
           default: '',
-          description: 'Leave blank for free personal use. Get an API key at https://open-meteo.com for commercial use or higher rate limits.'
+          description: 'Leave blank for free personal use. Go to https://open-meteo.com for a paid API.'
         }
       }
     }

--- a/src/lib/convert.ts
+++ b/src/lib/convert.ts
@@ -41,4 +41,44 @@ export class Convert {
   static fromUnixTime(val: number): number {
     return val * 1000
   }
+
+  // ******* Geohash ********
+  static geohash(lat: number, lon: number, precision = 5): string {
+    const base32 = '0123456789bcdefghjkmnpqrstuvwxyz'
+    let minLat = -90, maxLat = 90
+    let minLon = -180, maxLon = 180
+    let hash = ''
+    let isEven = true
+    let bit = 0
+    let ch = 0
+
+    while (hash.length < precision) {
+      if (isEven) {
+        const mid = (minLon + maxLon) / 2
+        if (lon >= mid) {
+          ch |= 1 << (4 - bit)
+          minLon = mid
+        } else {
+          maxLon = mid
+        }
+      } else {
+        const mid = (minLat + maxLat) / 2
+        if (lat >= mid) {
+          ch |= 1 << (4 - bit)
+          minLat = mid
+        } else {
+          maxLat = mid
+        }
+      }
+      isEven = !isEven
+      if (bit < 4) {
+        bit++
+      } else {
+        hash += base32[ch]
+        bit = 0
+        ch = 0
+      }
+    }
+    return hash
+  }
 }

--- a/src/weather/openmeteo.ts
+++ b/src/weather/openmeteo.ts
@@ -159,6 +159,10 @@ export class OpenMeteo {
     this.settings = config
   }
 
+  private getApiKeyParam(): string {
+    return this.settings.apiKey ? `&apikey=${this.settings.apiKey}` : ''
+  }
+
   private getMarineUrl(position: Position, options?: WeatherReqParams): string {
     if (!position) {
       return ''
@@ -178,7 +182,7 @@ export class OpenMeteo {
     const urlParam = `&hourly=${params.toString()}${forecastPeriod}`
     const pos = `&latitude=${position.latitude}&longitude=${position.longitude}`
     const url = `https://marine-api.open-meteo.com/v1/marine?timeformat=unixtime&wind_speed_unit=ms`
-    return `${url}${pos}${urlParam}`
+    return `${url}${pos}${urlParam}${this.getApiKeyParam()}`
   }
 
   private getUrl(
@@ -256,7 +260,7 @@ export class OpenMeteo {
         'daily'
       ].toString()}&current=${params['current'].toString()}${forecastPeriod}`
     }
-    return `${url}${pos}${urlParam}`
+    return `${url}${pos}${urlParam}${this.getApiKeyParam()}`
   }
 
   /**

--- a/src/weather/weather-service.ts
+++ b/src/weather/weather-service.ts
@@ -8,6 +8,7 @@ import {
 
 export interface WEATHER_CONFIG {
   apiKey?: string
+  cacheTTL?: number // cache time-to-live in minutes
 }
 
 const weatherServiceName = 'OpenMeteo'

--- a/src/weather/weather-service.ts
+++ b/src/weather/weather-service.ts
@@ -7,7 +7,7 @@ import {
 } from '@signalk/server-api'
 
 export interface WEATHER_CONFIG {
-  apiKey: string
+  apiKey?: string
 }
 
 const weatherServiceName = 'OpenMeteo'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
       "composite": true,
       "rootDir": "src",
       "sourceMap": false,
+      "skipLibCheck": true
     },
     "include": ["./src/**/*", "./src/openApi.json"],
     "exclude": ["node_modules", "plugin"],


### PR DESCRIPTION
Made use of API KEY Functional

  - src/weather/openmeteo.ts: Added getApiKeyParam() method that appends &apikey=... to URLs only when provided
  - src/index.ts: Updated description to "Leave blank for free personal use. Go to https://open-meteo.com for a paid API."

  Caching added for offline use

  - src/lib/convert.ts: Added geohash() function for generating location-based cache keys
  - src/weather/openmeteo.ts:
    - Added in-memory cache with configurable TTL
    - Cache key includes position geohash + request type + maxCount
  - src/weather/weather-service.ts: Added cacheTTL?: number to config interface
  - src/index.ts: Added "Cache TTL (minutes)" setting (default: 10)

  Forecast Hours Fix/change (Should a max hours/days be set in the plugin)

  - src/weather/openmeteo.ts: changed forecastPeriod logic:
   - Hourly (point) forecasts → only sets forecast_hours (default 24)
   
  Weather Description Bug Fix

  - src/weather/openmeteo.ts: Fixed weather_code: 0 ("Clear sky") returning empty description
    - Changed from weather_code ? ... to weather_code !== undefined ? ...
    - Fixed in parseCurrent(), and both loops in parseForecasts()

 I also had an issue building. I fixed but a bit of a hack:

  - tsconfig.json: Added "skipLibCheck": true to work around @js-temporal/polyfill type error
