### PR TITLE
perf: gate JSON.stringify behind debug.enabled

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -97,7 +97,9 @@ module.exports = (server: OpenMeteoProviderApp): Plugin => {
       settings.weather.apiKey = options.weather.apiKey ?? ''
       settings.weather.cacheTTL = options.weather.cacheTTL ?? 10
 
-      server.debug(`Applied config: ${JSON.stringify(settings)}`)
+      if (server.debug.enabled) {
+        server.debug(`Applied config: ${JSON.stringify(settings)}`)
+      }
 
       initWeather(server, plugin.id, settings.weather)
 


### PR DESCRIPTION
`start()` runs

```ts
server.debug(`Applied config: ${JSON.stringify(settings)}`)
```

once on startup. With debug logging off (the production default), `JSON.stringify` still runs eagerly and allocates a short-lived string.

This is one of the bigger perf taxes a SignalK plugin pays: the serialize cost compounds with GC pressure on hot paths. The same class of fix on `course-provider-plugin`'s dispatcher cut latency by ~70 % and dropped ~700 b/op of allocations on a single hot call site.

Start-only here, so the runtime gain is small — opening for consistency with the same fix landing across the other affected SK plugins.

## Change

- `src/index.ts` — wrap with `if (server.debug.enabled)`.